### PR TITLE
ログインできない不具合解消

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,6 @@ class User < ApplicationRecord
   has_many :time_cards
   belongs_to :company
 
-  enum is_displayed: { "表示": true, "非表示": false }
 
   #登録時にemailを不要とする
   def email_required?


### PR DESCRIPTION
user/modelにenumでis_displayedの日本語化をしたところログインできなくなってしまったのでそのコードを削除しました